### PR TITLE
Change TypicalPersons to TypicalOrders

### DIFF
--- a/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.TypicalIndexes.*;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalOrders.getTypicalAddressBookOrders;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +24,7 @@ import seedu.address.testutil.OrderBuilder;
  */
 public class EditOrderCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBookOrders(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {


### PR DESCRIPTION
Test should work now -- The issue was because TypicalPersons did not have any orders. 
Thus, we get a null exception when trying to get the first order, specifically in model.getFilteredOrderList().get(0). As model has no orders, getFilteredOrderList() returned a null. 