### PR TITLE
Adding tests for AddOrderCommandParser

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -52,6 +53,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String DETAILS_DESC_AMY = " " + PREFIX_DETAILS + VALID_DETAILS_AMY;
+    public static final String DETAILS_DESC_BOB = " "+ PREFIX_DETAILS + VALID_DETAILS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -60,6 +63,7 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_DETAILS_DESC = " " + PREFIX_DETAILS + " 1xchococake";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -54,7 +54,7 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String DETAILS_DESC_AMY = " " + PREFIX_DETAILS + VALID_DETAILS_AMY;
-    public static final String DETAILS_DESC_BOB = " "+ PREFIX_DETAILS + VALID_DETAILS_BOB;
+    public static final String DETAILS_DESC_BOB = " " + PREFIX_DETAILS + VALID_DETAILS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -63,7 +63,6 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-    public static final String INVALID_DETAILS_DESC = " " + PREFIX_DETAILS + " 1xchococake";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DETAILS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_DETAILS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -96,8 +95,8 @@ public class AddOrderCommandParserTest {
                 + DETAILS_DESC_AMY, Address.MESSAGE_CONSTRAINTS);
 
         // two invalid values - only first invalid value
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY + ADDRESS_DESC_AMY
-                + INVALID_DETAILS_DESC, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_PHONE_DESC + ADDRESS_DESC_AMY
+                + DETAILS_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
 
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_AMY + PHONE_DESC_AMY
             + DETAILS_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -1,21 +1,9 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.AddOrderCommand;
-import seedu.address.model.order.Details;
-import seedu.address.model.order.Order;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Phone;
-import seedu.address.testutil.OrderBuilder;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DETAILS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DETAILS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DETAILS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -26,8 +14,6 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -35,6 +21,16 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalOrders.AMY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddOrderCommand;
+import seedu.address.model.order.Order;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.testutil.OrderBuilder;
+
 
 public class AddOrderCommandParserTest {
     private AddOrderCommandParser parser = new AddOrderCommandParser();
@@ -44,20 +40,20 @@ public class AddOrderCommandParserTest {
         Order expectedOrder = new OrderBuilder(AMY).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY +
-                        ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY
+                + ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY +
-                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY
+                + ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
 
         // multiple phones - last phone accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_BOB + PHONE_DESC_AMY +
-                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_BOB + PHONE_DESC_AMY
+                + ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
 
         // multiple addresses - last address accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_BOB +
-                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_BOB
+                + ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
     }
 
     @Test
@@ -88,24 +84,20 @@ public class AddOrderCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
-                + DETAILS_DESC_AMY , Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + DETAILS_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
-        assertParseFailure(parser, NAME_DESC_AMY + INVALID_PHONE_DESC  + ADDRESS_DESC_AMY
-                + DETAILS_DESC_AMY , Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_AMY + INVALID_PHONE_DESC + ADDRESS_DESC_AMY
+                + DETAILS_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid address
-        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY  + INVALID_ADDRESS_DESC
-                + DETAILS_DESC_AMY , Address.MESSAGE_CONSTRAINTS);
-
-        // invalid details
-        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
-                + INVALID_DETAILS_DESC , Details.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_ADDRESS_DESC
+                + DETAILS_DESC_AMY, Address.MESSAGE_CONSTRAINTS);
 
         // two invalid values - only first invalid value
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
-                + INVALID_DETAILS_DESC , Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY + ADDRESS_DESC_AMY
+                + INVALID_DETAILS_DESC, Name.MESSAGE_CONSTRAINTS);
 
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_AMY + PHONE_DESC_AMY
             + DETAILS_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.AddOrderCommand;
+import seedu.address.model.order.Details;
+import seedu.address.model.order.Order;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.testutil.OrderBuilder;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DETAILS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DETAILS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DETAILS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalOrders.AMY;
+
+public class AddOrderCommandParserTest {
+    private AddOrderCommandParser parser = new AddOrderCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Order expectedOrder = new OrderBuilder(AMY).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY +
+                        ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+
+        // multiple names - last name accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + NAME_DESC_AMY + PHONE_DESC_AMY +
+                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+
+        // multiple phones - last phone accepted
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_BOB + PHONE_DESC_AMY +
+                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+
+        // multiple addresses - last address accepted
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_BOB +
+                ADDRESS_DESC_AMY + DETAILS_DESC_AMY, new AddOrderCommand(expectedOrder));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE);
+
+        // missing name prefix
+        assertParseFailure(parser, VALID_NAME_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + DETAILS_DESC_AMY,
+                expectedMessage);
+
+        // missing phone prefix
+        assertParseFailure(parser, NAME_DESC_AMY + VALID_PHONE_AMY + ADDRESS_DESC_AMY + DETAILS_DESC_AMY,
+                expectedMessage);
+
+        // missing address prefix
+        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY + VALID_ADDRESS_AMY + DETAILS_DESC_AMY,
+                expectedMessage);
+
+        // missing details prefix
+        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + VALID_DETAILS_AMY,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_NAME_AMY + VALID_PHONE_AMY + VALID_ADDRESS_AMY + VALID_DETAILS_AMY,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
+                + DETAILS_DESC_AMY , Name.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, NAME_DESC_AMY + INVALID_PHONE_DESC  + ADDRESS_DESC_AMY
+                + DETAILS_DESC_AMY , Phone.MESSAGE_CONSTRAINTS);
+
+        // invalid address
+        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY  + INVALID_ADDRESS_DESC
+                + DETAILS_DESC_AMY , Address.MESSAGE_CONSTRAINTS);
+
+        // invalid details
+        assertParseFailure(parser, NAME_DESC_AMY + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
+                + INVALID_DETAILS_DESC , Details.MESSAGE_CONSTRAINTS);
+
+        // two invalid values - only first invalid value
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_AMY  + ADDRESS_DESC_AMY
+                + INVALID_DETAILS_DESC , Name.MESSAGE_CONSTRAINTS);
+
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_AMY + PHONE_DESC_AMY
+            + DETAILS_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/address/testutil/TypicalOrders.java
@@ -6,6 +6,16 @@ import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.order.Order;
+import seedu.address.model.person.Person;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;;
 
 public class TypicalOrders {
     public static final Order EMILY = new OrderBuilder().withName("Emily Lee")
@@ -25,6 +35,15 @@ public class TypicalOrders {
             .withPhone("91029382")
             .withDetails("1xjerryfavouritecheesecake")
             .withComplete(false).build();
+
+
+    // Manually added - Person's details found in {@code CommandTestUtil}
+    public static final Order AMY = new OrderBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
+            .withDetails(VALID_DETAILS_AMY).withAddress(VALID_ADDRESS_AMY)
+            .build();
+    public static final Order BOB = new OrderBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+            .withDetails(VALID_DETAILS_BOB).withAddress(VALID_ADDRESS_BOB)
+            .build();
 
     private TypicalOrders() {} // prevents instantiation
 

--- a/src/test/java/seedu/address/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/address/testutil/TypicalOrders.java
@@ -1,13 +1,5 @@
 package seedu.address.testutil;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import seedu.address.model.AddressBook;
-import seedu.address.model.order.Order;
-import seedu.address.model.person.Person;
-
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_AMY;
@@ -15,7 +7,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.order.Order;
 
 public class TypicalOrders {
     public static final Order EMILY = new OrderBuilder().withName("Emily Lee")


### PR DESCRIPTION
Add tests for `AddOrderCommandParser` and investigated missing tests for `OrderTest`

Resolved issues
* `asObservableList_modifyList_throwsUnsupportedOperationException` is present in `PersonTest` but not `OrderTest`. This is due to the potential mutability of `Tag` in Person as tags are stored as a set. This test is meant to check that the tags of a Person should be and unmodifiable set, and hence cannot be changed indirectly.

Issues uncovered:
* Validation regex check for Details are not triggered. Currently, the constraint for Details is that it must not contain whitespaces characters, but due to `ArgumentTokenizer.tokenize()` trimming values, details with whitespace characters in front can be successfully passed. Issue to be resolved in #118.
