### PR TITLE
Fix bug in UI

### DIFF
--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: #383838;
+    -fx-background: white;
 }
 
 .tag-selector {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -32,7 +32,7 @@
           </Menu>
         </MenuBar>
 
-        <VBox fx:id="resultList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="NEVER">
+        <VBox fx:id="resultList" minWidth="340" prefWidth="340" styleClass="result-list-pane-with-border" VBox.vgrow="NEVER">
         </VBox>
 
         <StackPane fx:id="responseDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100"

--- a/src/main/resources/view/ReadyBakeyTheme.css
+++ b/src/main/resources/view/ReadyBakeyTheme.css
@@ -102,7 +102,7 @@
 
     -fx-border-radius: 15px;
     -fx-border-width: 5px;
-    -fx-border-color: black;
+    -fx-border-color: white;
 }
 
 .list-cell:filled:even {
@@ -111,15 +111,6 @@
 
 .list-cell:filled:odd {
     -fx-background-color: #CA9E7B;
-}
-
-.list-cell:filled:selected {
-    -fx-background-color: #424d5f;
-}
-
-.list-cell:filled:selected #cardPane {
-    -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
 }
 
 .list-cell .label {
@@ -287,30 +278,54 @@
     -fx-text-fill: white;
 }
 
-.scroll-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
+.scroll-bar:horizontal .track,
+.scroll-bar:vertical .track{
+    -fx-background-color :transparent;
+    -fx-border-color :transparent;
+    -fx-background-radius : 0.0em;
+    -fx-border-radius :2.0em;
 }
 
-.scroll-bar .thumb {
-    -fx-background-color: derive(#1d1d1d, 50%);
-    -fx-background-insets: 3;
+
+.scroll-bar:horizontal .increment-button ,
+.scroll-bar:horizontal .decrement-button {
+    -fx-background-color :transparent;
+    -fx-background-radius : 0.0em;
+    -fx-padding :0.0 0.0 10.0 0.0;
+
 }
 
-.scroll-bar .increment-button, .scroll-bar .decrement-button {
-    -fx-background-color: transparent;
-    -fx-padding: 0 0 0 0;
+.scroll-bar:vertical .increment-button ,
+.scroll-bar:vertical .decrement-button {
+    -fx-background-color :transparent;
+    -fx-background-radius : 0.0em;
+    -fx-padding :0.0 10.0 0.0 0.0;
 }
 
-.scroll-bar .increment-arrow, .scroll-bar .decrement-arrow {
-    -fx-shape: " ";
+.scroll-bar .increment-arrow,
+.scroll-bar .decrement-arrow{
+    -fx-shape : " ";
+    -fx-padding :0.15em 0.0;
 }
 
-.scroll-bar:vertical .increment-arrow, .scroll-bar:vertical .decrement-arrow {
-    -fx-padding: 1 8 1 8;
+.scroll-bar:vertical .increment-arrow,
+.scroll-bar:vertical .decrement-arrow{
+    -fx-shape : " ";
+    -fx-padding :0.0 0.15em;
 }
 
-.scroll-bar:horizontal .increment-arrow, .scroll-bar:horizontal .decrement-arrow {
-    -fx-padding: 8 1 8 1;
+.scroll-bar:horizontal .thumb,
+.scroll-bar:vertical .thumb {
+    -fx-background-color :derive(black,95.0%);
+    -fx-background-insets : 2.0, 0.0, 0.0;
+    -fx-background-radius : 2.0em;
+}
+
+.scroll-bar:horizontal .thumb:hover,
+.scroll-bar:vertical .thumb:hover {
+    -fx-background-color :derive(#4D4C4F,10.0%);
+    -fx-background-insets : 2.0, 0.0, 0.0;
+    -fx-background-radius : 2.0em;
 }
 
 #cardPane {


### PR DESCRIPTION
Selecting a card used to leave it selected regardless of where you click. 
- Removed select option in the UI. 
- Not 100% complete as there is still an option to select in FXML code. 

The result list is not changing the background as expected. 
- Need to find a way to change it. 
- Added borders to set the distance between each card. 
   - This is the fastest way to get spacing between the cards but is not consistent between the first card's top portion vs between other cards. 
   - There is a weird border outside the supposed border as well.

I will attempt to fix the spacing issue again and change the background of the listing of both orders and persons to be white. May also look for a new way to introduce a spacing between the cards.