### PR TITLE
Fix blue box bug in UI

### DIFF
--- a/src/main/resources/view/ReadyBakeyTheme.css
+++ b/src/main/resources/view/ReadyBakeyTheme.css
@@ -95,14 +95,8 @@
 }
 
 .list-cell {
-    -fx-padding: 5px;
+    -fx-background-color: transparent;
 
-    -fx-background-color: #2969c0;
-    -fx-background-radius: 15px;
-
-    -fx-border-radius: 15px;
-    -fx-border-width: 5px;
-    -fx-border-color: white;
 }
 
 .list-cell:filled:even {


### PR DESCRIPTION
Set the boxes unfilled with `transparent` instead of `white` to remove it from sight of the application. No more border radius to keep things simple.

Potentially remove borders in the resultpane in the future and add avatar next.

Part of #115 