### PR TITLE
Update EditOrderCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditOrderCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import java.util.List;
@@ -32,8 +32,14 @@ public class EditOrderCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_DETAILS + "DETAILS "
+            + PREFIX_REMARK + "REMARK "
+            + PREFIX_DELIVERYDATETIME + "DELIVERYDATETIME "
+            + PREFIX_COLLECTION_TYPE + "COLLECTION_TYPE \n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_DETAILS + "1x Jerry Favourite Cheese Cake";
+            + PREFIX_REMARK + "Add Cheese "
+            + PREFIX_DETAILS + "1: Jerry Favourite Cheese Cake, 2: Chocolate Cake "
+            + PREFIX_DELIVERYDATETIME + "25-12-2022 15:30 "
+            + PREFIX_COLLECTION_TYPE + "Delivery";
 
     public static final String MESSAGE_EDIT_ORDER_SUCCESS = "Edited Order: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/EditOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditOrderCommand.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COLLECTION_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DELIVERYDATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import java.util.List;

--- a/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB_ORDER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COLLECTIONTYPE_BOB_TYPE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DELIVERYDATETIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DETAILS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertOrderCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showOrderAtIndex;
@@ -65,6 +66,35 @@ public class EditOrderCommandTest {
                 .withCollectionType(VALID_COLLECTIONTYPE_BOB_TYPE).build();
 
 
+
+        EditOrderCommand editOrderCommand = new EditOrderCommand(indexLastOrder, descriptor);
+
+        String expectedMessage = String.format(EditOrderCommand.MESSAGE_EDIT_ORDER_SUCCESS, editedOrder);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setOrder(lastOrder, editedOrder);
+
+        assertOrderCommandSuccess(editOrderCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_DetailsRemarksCompletionDateSpecifiedUnfilteredList_success() {
+        Index indexLastOrder = Index.fromOneBased(model.getFilteredOrderList().size());
+        Order lastOrder = model.getFilteredOrderList().get(indexLastOrder.getZeroBased());
+
+        OrderBuilder orderInList = new OrderBuilder(lastOrder);
+
+        Order editedOrder = orderInList
+                .withDetails(VALID_DETAILS_BOB)
+                .withDeliveryDateTime(VALID_DELIVERYDATETIME_BOB)
+                .withRemark(VALID_REMARK_BOB)
+                .withCollectionType(VALID_COLLECTIONTYPE_BOB_TYPE).build();
+
+        EditOrderDescriptor descriptor = new EditOrderDescriptorBuilder()
+                .withDetails(VALID_DETAILS_BOB)
+                .withDeliveryDateTime(VALID_DELIVERYDATETIME_BOB)
+                .withRemark(VALID_REMARK_BOB)
+                .withCollectionType(VALID_COLLECTIONTYPE_BOB_TYPE).build();
 
         EditOrderCommand editOrderCommand = new EditOrderCommand(indexLastOrder, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditOrderCommandTest.java
@@ -35,7 +35,7 @@ public class EditOrderCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBookOrders(), new UserPrefs());
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_detailsFieldSpecifiedUnfilteredList_success() {
         Order editedOrder = new OrderBuilder(model.getFilteredOrderList().get(0))
                 .withDetails("1: Choc Cake").build(); // Creates the order in orderbuilder
         EditOrderDescriptor descriptor = new EditOrderDescriptorBuilder(editedOrder).build();
@@ -78,7 +78,7 @@ public class EditOrderCommandTest {
     }
 
     @Test
-    public void execute_DetailsRemarksCompletionDateSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Index indexLastOrder = Index.fromOneBased(model.getFilteredOrderList().size());
         Order lastOrder = model.getFilteredOrderList().get(indexLastOrder.getZeroBased());
 


### PR DESCRIPTION
EditOrderCommand's response message now provides details on using all potential prefixes available to the users. This includes the details, remarks, delivery datetime, and collection type.

Added one test to catch when all prefixes are provided to readybakey.

Closes #100 