### PR TITLE
Implement some fixes for add order command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
@@ -24,7 +24,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.person.Remark;
 
-
 /**
  * Changes the remark of an existing person in ReadyBakey.
  */

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -44,7 +44,6 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
         CollectionType collectionType = ParserUtil.parseCollectionType(
                 argMultimap.getValue(PREFIX_COLLECTION_TYPE).get());
 
-
         return new AddOrderCommand(phone, remark, details, deliveryDateTime, collectionType);
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,8 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DETAILS = new Prefix("d/");
-    public static final Prefix PREFIX_DELIVERYDATETIME = new Prefix("c/");
-    public static final Prefix PREFIX_COLLECTION_TYPE = new Prefix("g/");
+    public static final Prefix PREFIX_DELIVERYDATETIME = new Prefix("m/");
+    public static final Prefix PREFIX_COLLECTION_TYPE = new Prefix("c/");
     public static final Prefix PREFIX_BLANK = new Prefix("");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,8 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_DETAILS = new Prefix("d/");
-    public static final Prefix PREFIX_DELIVERYDATETIME = new Prefix("m/");
-    public static final Prefix PREFIX_COLLECTION_TYPE = new Prefix("c/");
+    public static final Prefix PREFIX_DELIVERYDATETIME = new Prefix("c/");
+    public static final Prefix PREFIX_COLLECTION_TYPE = new Prefix("m/");
     public static final Prefix PREFIX_BLANK = new Prefix("");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -185,7 +185,7 @@ public class ParserUtil {
         String parsedDeliveryDateTime = DateChecker.parsePotentialNaturalDate(trimmedDeliveryDateTime);
         if (!DeliveryDateTime.isValidDeliveryDateTime(parsedDeliveryDateTime)) {
             throw new ParseException(DeliveryDateTime.MESSAGE_CONSTRAINTS);
-        } else if (!DeliveryDateTime.isValidLeapYearDeliveryDateTimeValue(trimmedDeliveryDateTime)) {
+        } else if (!DeliveryDateTime.isValidLeapYearDeliveryDateTimeValue(parsedDeliveryDateTime)) {
             throw new ParseException(DeliveryDateTime.MESSAGE_CONSTRAINTS_LEAP_YEAR);
         }
         return new DeliveryDateTime(parsedDeliveryDateTime);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -182,6 +182,8 @@ public class ParserUtil {
         String trimmedDeliveryDateTime = deliveryDateTime.trim();
         if (!DeliveryDateTime.isValidDeliveryDateTime(trimmedDeliveryDateTime)) {
             throw new ParseException(DeliveryDateTime.MESSAGE_CONSTRAINTS);
+        } else if (!DeliveryDateTime.isValidLeapYearDeliveryDateTimeValue(trimmedDeliveryDateTime)) {
+            throw new ParseException(DeliveryDateTime.MESSAGE_CONSTRAINTS_LEAP_YEAR);
         }
         return new DeliveryDateTime(trimmedDeliveryDateTime);
     }

--- a/src/main/java/seedu/address/model/order/DeliveryDateTime.java
+++ b/src/main/java/seedu/address/model/order/DeliveryDateTime.java
@@ -16,6 +16,9 @@ public class DeliveryDateTime {
     public static final String MESSAGE_CONSTRAINTS = "DeliveryDateTime should be in the format dd/MM/yyyy HH:mm "
             + "and should be a valid date and time before today's date!";
 
+    public static final String MESSAGE_CONSTRAINTS_LEAP_YEAR = "Your current input represents a leap day but the "
+            + "year is not a leap year! Please check the date again!";
+
     /*
      * The first character of the deliveryDateTime must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
@@ -34,6 +37,7 @@ public class DeliveryDateTime {
     public DeliveryDateTime(String deliveryDateTime) {
         requireNonNull(deliveryDateTime);
         checkArgument(isValidDeliveryDateTime(deliveryDateTime), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidLeapYearDeliveryDateTimeValue(deliveryDateTime), MESSAGE_CONSTRAINTS_LEAP_YEAR);
         value = LocalDateTime.parse(deliveryDateTime, PARSER_FORMATTER);
     }
 
@@ -55,6 +59,36 @@ public class DeliveryDateTime {
         }
         return true;
     }
+
+    /**
+     * Returns true if a given string is a valid email.
+     */
+    public static boolean isValidLeapYearDeliveryDateTimeValue(String test) {
+        String[] date = test.split(" ");
+        String[] dateSplit = date[0].split("-");
+        int day = Integer.parseInt(dateSplit[0]);
+        int month = Integer.parseInt(dateSplit[1]);
+        int year = Integer.parseInt(dateSplit[2]);
+        boolean onLeapDay = (month == 2) && (day == 29);
+        if (onLeapDay) {
+            if (isLeapYear(year)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if a given string is a valid email.
+     */
+    public static boolean isLeapYear(int year) {
+        //@@author {https://www.geeksforgeeks.org/java-program-to-find-if-a-given-year-is-a-leap-year/} - reused
+        return ((year % 400 == 0)
+                || ((year % 4 == 0) && (year % 100 != 0)));
+        //@@author
+        }
 
     /**
      * Returns true if a given string is a valid datetime.

--- a/src/main/java/seedu/address/model/order/DeliveryDateTime.java
+++ b/src/main/java/seedu/address/model/order/DeliveryDateTime.java
@@ -88,7 +88,7 @@ public class DeliveryDateTime {
         return ((year % 400 == 0)
                 || ((year % 4 == 0) && (year % 100 != 0)));
         //@@author
-        }
+    }
 
     /**
      * Returns true if a given string is a valid datetime.

--- a/src/main/java/seedu/address/model/order/Details.java
+++ b/src/main/java/seedu/address/model/order/Details.java
@@ -115,7 +115,7 @@ public class Details {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Details // instanceof handles nulls
-                && value.equals(((Details) other).value)); // state check
+                && value.equalsIgnoreCase(((Details) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -109,7 +110,7 @@ public class Order {
         Order otherOrder = (Order) other;
 
         return otherOrder.getUuid().equals(getUuid())
-                && otherOrder.getDetails().equals(getDetails())
+                && new HashSet<>(otherOrder.getDetails()).equals(new HashSet<>(getDetails()))
                 && otherOrder.getDeliveryDateTime().equals(getDeliveryDateTime());
     }
 

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -64,7 +64,6 @@ public class Order {
         return Collections.unmodifiableList(details);
     }
 
-
     public Remark getRemark() {
         return remark;
     }
@@ -110,10 +109,8 @@ public class Order {
         Order otherOrder = (Order) other;
 
         return otherOrder.getUuid().equals(getUuid())
-                && otherOrder.getRemark().equals(getRemark())
                 && otherOrder.getDetails().equals(getDetails())
-                && otherOrder.getDeliveryDateTime().equals(getDeliveryDateTime())
-                && otherOrder.getCollectionType().equals(getCollectionType());
+                && otherOrder.getDeliveryDateTime().equals(getDeliveryDateTime());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 70 characters), and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 70 characters)";
 
     /*
      * The first character of the remark must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -8,13 +8,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 50 characters), and it should not be blank";
 
     /*
      * The first character of the remark must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = ".*";
+    public static final String VALIDATION_REGEX = ".{0,70}";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 50 characters), and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 70 characters), and it should not be blank";
 
     /*
      * The first character of the remark must not be a whitespace,

--- a/src/test/java/seedu/address/model/order/DeliveryDateTimeTest.java
+++ b/src/test/java/seedu/address/model/order/DeliveryDateTimeTest.java
@@ -21,17 +21,26 @@ public class DeliveryDateTimeTest {
 
     @Test
     public void isValidDeliveryDateTime() {
-        // null address
+        // null datetime
         assertThrows(NullPointerException.class, () -> DeliveryDateTime.isValidDeliveryDateTime(null));
 
-        // invalid addresses
+        // invalid datetime
         assertFalse(DeliveryDateTime.isValidDeliveryDateTime("")); // empty string
         assertFalse(DeliveryDateTime.isValidDeliveryDateTime(" ")); // spaces only
         assertFalse(DeliveryDateTime.isValidDeliveryDateTime("15/12/13 13:43")); // wrong date format
         assertFalse(DeliveryDateTime.isValidDeliveryDateTime("15-12-2022 1340")); // wrong time format
         assertFalse(DeliveryDateTime.isValidDeliveryDateTime("15-01-2022 13:40")); // Before current datetime
 
-        // valid addresses
+        // valid datetime
         assertTrue(DeliveryDateTime.isValidDeliveryDateTime("25-06-2022 18:30"));
+
+        // valid datetime leapyear
+        assertTrue(DeliveryDateTime.isValidDeliveryDateTime("29-02-2024 18:30"));
+
+        //invalid datetime leapyear
+        assertTrue(DeliveryDateTime.isValidDeliveryDateTime("29-02-2023 18:30"));
+        assertTrue(DeliveryDateTime.isValidDeliveryDateTime("29-02-3000 18:30"));
+
+
     }
 }

--- a/src/test/java/seedu/address/model/order/OrderTest.java
+++ b/src/test/java/seedu/address/model/order/OrderTest.java
@@ -47,17 +47,18 @@ public class OrderTest {
         editedEmily = new OrderBuilder(EMILY).withDetails(VALID_DETAILS_BOB).build();
         assertFalse(EMILY.equals(editedEmily));
 
-        // different remarks -> returns false
+        // different remarks -> returns true
         editedEmily = new OrderBuilder(EMILY).withRemark(VALID_REMARK_BOB).build();
-        assertFalse(EMILY.equals(editedEmily));
+        assertTrue(EMILY.equals(editedEmily));
 
         // different deliveryDateTime -> returns false
         editedEmily = new OrderBuilder(EMILY).withDeliveryDateTime(VALID_DELIVERYDATETIME_BOB).build();
         assertFalse(EMILY.equals(editedEmily));
 
-        // different collectionType -> returns false
+        // different collectionType -> returns true
         editedEmily = new OrderBuilder(EMILY).withCollectionType(CollectionType.PICKUP).build();
-        assertFalse(EMILY.equals(editedEmily));
+        assertTrue(EMILY.equals(editedEmily));
+
 
     }
 }

--- a/src/test/java/seedu/address/model/person/RemarkTest.java
+++ b/src/test/java/seedu/address/model/person/RemarkTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -21,7 +22,9 @@ public class RemarkTest {
         assertTrue(Remark.isValidRemark("In love with sky diving"));
         assertTrue(Remark.isValidRemark("-")); // one character
         assertTrue(Remark.isValidRemark("")); // empty remark
-        assertTrue(Remark.isValidRemark("Waterfall Enthusiast who also loves to play water sports, "
-                + "board games, watch movies and loves gambling")); // long remark
+        assertTrue(Remark.isValidRemark("Waterfall Enthusiast who loves to play "
+                + "water sports and loves car race")); // long remark exactly 70 characters long
+        assertFalse(Remark.isValidRemark("Waterfall Enthusiast who also loves to play water sports, "
+                + "board games, watch movies and loves gambling")); // long remark above 70 characters
     }
 }


### PR DESCRIPTION
Lets change the prefixes to be more user friendly
- deliverydatetime - "c"
- collectionType - "m"

Lets also implement a leap year checker in case the user inputs a leap year as a datetime. 
Currently, LocalDateTime implementation automatically parses a non leap year to the day before (29-02-2023) --> (28-02-2023). This should not be the case. I implement a leap year checker to check for this instance and inform the user if his leap day does not lie on a leap year

Lets also edit orders' equality implementation. Orders are equal if they have the same details & deliverydatetime & uuid

Lets also edit details' equality implementation. Previously, order is taken into account
"1:Cake 1:Banana" is the same as "1:Banana 1:Cake". The code has been changed to take order into account by parsing the list into a hashes solely for equality checking


