### PR TITLE
Edit condition for findo parsing (details)

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindOrderCommandParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindOrderPhoneCommand;
 import seedu.address.logic.commands.FindOrderRemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.CollectionTypeContainsKeywordsPredicate;
+import seedu.address.model.order.Details;
 import seedu.address.model.order.DetailsContainsKeywordsPredicate;
 import seedu.address.model.order.RemarkContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -31,6 +32,7 @@ public class FindOrderCommandParser implements Parser<FindOrderCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindOrderCommand
      * and returns a FindOrderCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindOrderCommand parse(String args) throws ParseException {
@@ -52,6 +54,7 @@ public class FindOrderCommandParser implements Parser<FindOrderCommand> {
             String[] remarkKeywords = getKeywords(argMultimap, PREFIX_REMARK);
             return new FindOrderRemarkCommand(new RemarkContainsKeywordsPredicate(Arrays.asList(remarkKeywords)));
         } else if (isOnlyOnePrefixPresent(argMultimap, PREFIX_DETAILS)) {
+            checkDetailsItemKeyword(argMultimap, PREFIX_DETAILS);
             String[] detailsKeywords = getKeywords(argMultimap, PREFIX_DETAILS);
             return new FindOrderDetailsCommand(new DetailsContainsKeywordsPredicate(Arrays.asList(detailsKeywords)));
         } else if (isOnlyOnePrefixPresent(argMultimap, PREFIX_COLLECTION_TYPE)) {
@@ -72,4 +75,12 @@ public class FindOrderCommandParser implements Parser<FindOrderCommand> {
         }
         return keywordString.split("\\s+");
     }
+
+    private static void checkDetailsItemKeyword(ArgumentMultimap argMultiMap, Prefix findPrefix) throws ParseException {
+        if (!Details.isValidFindDetailsItem(argMultiMap.getValue(findPrefix).get().trim())) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Details.FIND_ITEM_MESSAGE_CONSTRAINTS));
+        }
+    }
 }
+

--- a/src/main/java/seedu/address/model/order/Details.java
+++ b/src/main/java/seedu/address/model/order/Details.java
@@ -118,7 +118,7 @@ public class Details {
 
     @Override
     public String toString() {
-        return value;
+        return String.valueOf(quantity) + ": " + item;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/order/Details.java
+++ b/src/main/java/seedu/address/model/order/Details.java
@@ -23,6 +23,8 @@ public class Details {
     public static final String MESSAGE_CONSTRAINTS = "Details consists of a number (quantity), "
             + "followed by a colon (:) and by alphabetical or whitespace characters (order item). "
             + "\n EXAMPLE: d/1: vanilla cake";
+    public static final String FIND_ITEM_MESSAGE_CONSTRAINTS = "findo only supports finding items and not quantities\n"
+            + "EXAMPLE: findo d/Cake";
     /*
      * Details passed in should follow convention eg. "1 : chocolate cake with sprinkles".
      * Characters preceding the colon should only be numerical. This is parsed as the quantity.
@@ -33,6 +35,7 @@ public class Details {
     private static final String VALIDATION_REGEX = String.format(
             "^(\\s+)?(?<%s>\\d+)\\s*:{1}\\s*(?<%s>((\\w|\\w )+))(\\s+)?$",
             ORDER_QUANTITY_REGEX_KEYWORD, ORDER_ITEM_REGEX_KEYWORD);
+    private static final String VALIDATION_REGEX_QUANTITY = "^([0-9]+:).*";
     private static final Pattern DETAIL_PATTERN = Pattern.compile(VALIDATION_REGEX);
 
     public final String value;
@@ -88,6 +91,13 @@ public class Details {
      */
     public static boolean isValidDetails(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a valid detail item.
+     */
+    public static boolean isValidFindDetailsItem(String test) {
+        return !test.matches(VALIDATION_REGEX_QUANTITY);
     }
 
     /**


### PR DESCRIPTION
Now, a user is able to parse in findo details in the format "quantity: item".
However, a user should only be allowed to parse details item and not quantity.

As long as the user parses "[+ve int]:" at the start of a `findo d/` command, it should not be allowed.

If this case was allowed, it could be confusing to the user:
For example the user parses `findo d/2: cake`: This could cause return values such as:
- 1: cake
- 3: cake

which can confuse the user due to differing quantity names. As a result, solely for findo d/, we prevent this from happening by checking if
`[quantity]:` is at the start of a findo d/ parse and return an error to the user


Also change details toString to ensure whitespace is not shown