### PR TITLE
Update prefix defense

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,13 +3,13 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_MAX_INPUT_LIMIT;
 import static seedu.address.commons.core.Messages.MESSAGE_MAX_SIZE_LIMIT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BLANK;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.model.order.Details.ITEM_MESSAGE_LIMIT;
 import static seedu.address.model.order.Details.ITEM_SIZE_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_MESSAGE_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_SIZE_MAX_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_SIZE_MIN_LIMIT;
+import static seedu.address.model.person.Address.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,8 +92,11 @@ public class ParserUtil {
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
         String trimmedAddress = address.trim();
+        int trimmedAddressLength = trimmedAddress.length();
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
+        } else if (trimmedAddressLength < ADDRESS_SIZE_MIN_LIMIT || trimmedAddressLength > ADDRESS_SIZE_MAX_LIMIT) {
+            throw new ParseException(String.format(MESSAGE_ADDRESS_LIMIT, PREFIX_ADDRESS));
         }
         return new Address(trimmedAddress);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,13 +3,29 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_MAX_INPUT_LIMIT;
 import static seedu.address.commons.core.Messages.MESSAGE_MAX_SIZE_LIMIT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BLANK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.order.Details.ITEM_MESSAGE_LIMIT;
 import static seedu.address.model.order.Details.ITEM_SIZE_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_MESSAGE_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_SIZE_MAX_LIMIT;
 import static seedu.address.model.order.Details.QUANTITY_SIZE_MIN_LIMIT;
-import static seedu.address.model.person.Address.*;
+import static seedu.address.model.person.Address.ADDRESS_SIZE_MAX_LIMIT;
+import static seedu.address.model.person.Address.ADDRESS_SIZE_MIN_LIMIT;
+import static seedu.address.model.person.Address.MESSAGE_ADDRESS_LIMIT;
+import static seedu.address.model.person.Email.EMAIL_SIZE_MAX_LIMIT;
+import static seedu.address.model.person.Email.EMAIL_SIZE_MIN_LIMIT;
+import static seedu.address.model.person.Email.MESSAGE_EMAIL_LIMIT;
+import static seedu.address.model.person.Name.MESSAGE_NAME_LIMIT;
+import static seedu.address.model.person.Name.NAME_SIZE_MAX_LIMIT;
+import static seedu.address.model.person.Name.NAME_SIZE_MIN_LIMIT;
+import static seedu.address.model.person.Phone.MESSAGE_PHONE_LIMIT;
+import static seedu.address.model.person.Phone.PHONE_SIZE_MAX_LIMIT;
+import static seedu.address.model.person.Phone.PHONE_SIZE_MIN_LIMIT;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -62,8 +78,11 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+        int trimmedNameLength = trimmedName.length();
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        } else if (trimmedNameLength < NAME_SIZE_MIN_LIMIT || trimmedNameLength > NAME_SIZE_MAX_LIMIT) {
+            throw new ParseException(String.format(MESSAGE_NAME_LIMIT, PREFIX_NAME));
         }
         return new Name(trimmedName);
     }
@@ -77,8 +96,11 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
+        int trimmedPhoneLength = trimmedPhone.length();
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+        } else if (trimmedPhoneLength < PHONE_SIZE_MIN_LIMIT || trimmedPhoneLength > PHONE_SIZE_MAX_LIMIT) {
+            throw new ParseException(String.format(MESSAGE_PHONE_LIMIT, PREFIX_PHONE));
         }
         return new Phone(trimmedPhone);
     }
@@ -125,8 +147,11 @@ public class ParserUtil {
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
         String trimmedEmail = email.trim();
+        int trimmedEmailLength = trimmedEmail.length();
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+        } else if (trimmedEmailLength < EMAIL_SIZE_MIN_LIMIT || trimmedEmailLength > EMAIL_SIZE_MAX_LIMIT) {
+            throw new ParseException(String.format(MESSAGE_EMAIL_LIMIT, PREFIX_EMAIL));
         }
         return new Email(trimmedEmail);
     }

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
-public class Address<MESSAGE_MAX_INPUT_LIMIT> {
+public class Address {
 
     public static final int ADDRESS_SIZE_MIN_LIMIT = 6;
     public static final int ADDRESS_SIZE_MAX_LIMIT = 100;

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Address {
 
     public static final int ADDRESS_SIZE_MIN_LIMIT = 6;
-    public static final int ADDRESS_SIZE_MAX_LIMIT = 100;
+    public static final int ADDRESS_SIZE_MAX_LIMIT = 70;
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
     public static final String MESSAGE_ADDRESS_LIMIT = "An address cannot be shorter than " + ADDRESS_SIZE_MIN_LIMIT
             + " characters and cannot be longer than " + ADDRESS_SIZE_MAX_LIMIT + ". ";

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -7,9 +7,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
-public class Address {
+public class Address<MESSAGE_MAX_INPUT_LIMIT> {
 
+    public static final int ADDRESS_SIZE_MIN_LIMIT = 6;
+    public static final int ADDRESS_SIZE_MAX_LIMIT = 100;
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_ADDRESS_LIMIT = "An address cannot be shorter than " + ADDRESS_SIZE_MIN_LIMIT
+            + " characters and cannot be longer than " + ADDRESS_SIZE_MAX_LIMIT + ". ";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,6 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    public static final int EMAIL_SIZE_MIN_LIMIT = 6;
+    public static final int EMAIL_SIZE_MAX_LIMIT = 50;
+    public static final String MESSAGE_EMAIL_LIMIT = "Customer's email cannot be shorter than " + EMAIL_SIZE_MIN_LIMIT
+            + " characters and cannot be longer than " + EMAIL_SIZE_MAX_LIMIT + ". ";
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -9,9 +9,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
+    public static final int NAME_SIZE_MIN_LIMIT = 2;
+    public static final int NAME_SIZE_MAX_LIMIT = 50;
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-
+    public static final String MESSAGE_NAME_LIMIT = "Customer's name cannot be shorter than " + NAME_SIZE_MIN_LIMIT
+            + " characters and cannot be longer than " + NAME_SIZE_MAX_LIMIT + ". ";
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -9,10 +9,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Phone {
 
-
+    public static final int PHONE_SIZE_MIN_LIMIT = 3;
+    public static final int PHONE_SIZE_MAX_LIMIT = 15;
+    public static final String MESSAGE_PHONE_LIMIT = "Customer's phone cannot be shorter than " + PHONE_SIZE_MIN_LIMIT
+            + " characters and cannot be longer than " + PHONE_SIZE_MAX_LIMIT + ". ";
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers";
+    public static final String VALIDATION_REGEX = "[0-9]+";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -8,7 +8,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values (up to 70 characters)";
+    public static final int REMARK_SIZE_MAX_LIMIT = 70;
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values, but only up to "
+            + REMARK_SIZE_MAX_LIMIT + " characters";
 
     /*
      * The first character of the remark must not be a whitespace,

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -27,7 +27,6 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
@@ -35,6 +34,7 @@ public class PhoneTest {
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("1293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("123456789112345")); // 15 char phone numbers
     }
 }


### PR DESCRIPTION
Add restrictions to the character length of address at 6-100 chars. The rationale for 6 is to ensure that users can put purely postal code if they have no time to key the full address.

Added restrictions to the name as well. It cannot go over 50 chars and below 2 chars.

Emails are restricted to 6-50 chars.

Testing of char limits should be done with ParserUtil. It is where all the exceptions are thrown and would be a better way to consolidate all exceptions.

Removed phone char limit validation in Phone to provide better error messages. Moved this to ParserUtil instead.

I will work on adding tests for these restrictions in the following milestone.